### PR TITLE
Improve DAG layout with graphviz and fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ streamlit run projektplan_app.py
 - Dynamische Eingabe der Meilensteine und Abhängigkeiten
 - Visualisierung als gerichteter Graph
 - Intuitive Benutzeroberfläche
+- Optionales DAG-Layout über `pygraphviz` (`graphviz_layout` mit `dot`); ohne `pygraphviz` wird auf `planar_layout` bzw. `shell_layout` zurückgegriffen

--- a/projektplan_app.py
+++ b/projektplan_app.py
@@ -45,7 +45,16 @@ if st.button("📊 Liniennetzplan erstellen"):
                             G.add_edge(v, ms_id)
 
             # Layout und Zeichnen
-            pos = nx.spring_layout(G, k=1, iterations=50)
+            try:
+                from networkx.drawing.nx_agraph import graphviz_layout
+                pos = graphviz_layout(G, prog="dot")
+            except (ImportError, nx.NetworkXException):
+                # Fallback, falls pygraphviz nicht verfügbar oder Layout fehlschlägt
+                try:
+                    pos = nx.planar_layout(G)
+                except (nx.NetworkXException, ValueError):
+                    pos = nx.shell_layout(G)
+
             labels = nx.get_node_attributes(G, 'label')
 
             fig, ax = plt.subplots(figsize=(10, 7))


### PR DESCRIPTION
## Summary
- Use `graphviz_layout` with `dot` for clearer DAG visualization when `pygraphviz` is available
- Fall back to `planar_layout` or `shell_layout` when `pygraphviz` or planar layout fails
- Document optional `pygraphviz` dependency and layout fallback

## Testing
- `python -m py_compile projektplan_app.py`


------
https://chatgpt.com/codex/tasks/task_b_6892662fd614832f8d122ade0e0aaa84